### PR TITLE
chore(): fix bug with not centered carousel images

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1061,7 +1061,7 @@ export default class Carousel extends Component {
     _getComponentStaticProps () {
         const { hideCarousel } = this.state;
         const {
-            activeSlideAlignment, CellRendererComponent, containerCustomStyle,
+            CellRendererComponent, containerCustomStyle,
             contentContainerCustomStyle, firstItem, getItemLayout, keyExtractor,
             sliderWidth, sliderHeight, style, useExperimentalSnap, vertical
         } = this.props;
@@ -1086,7 +1086,7 @@ export default class Carousel extends Component {
         };
 
         const contentContainerStyle = [
-            !useExperimentalSnap ? innerMarginStyle : {},
+            innerMarginStyle,
             contentContainerCustomStyle || {}
         ];
 
@@ -1098,7 +1098,6 @@ export default class Carousel extends Component {
         // Recommended only with large slides and `activeSlideAlignment` set to `start` for the time being
         const snapProps = useExperimentalSnap ? {
             // disableIntervalMomentum: true, // Slide ± one item at a time
-            snapToAlignment: activeSlideAlignment,
             snapToInterval: this._getItemMainDimension()
         } : {
             snapToOffsets: this._getSnapOffsets()


### PR DESCRIPTION
### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
